### PR TITLE
example

### DIFF
--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -3,6 +3,7 @@ package start
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/luthermonson/go-proxmox"
 	"github.com/sirupsen/logrus"
@@ -13,7 +14,7 @@ var Command = &cli.Command{
 	Name:   "start",
 	Usage:  "start",
 	Action: startVm,
-	Flags:  []cli.Flag{
+	Flags: []cli.Flag{
 		&cli.Uint64Flag{
 			Name:        "vmid",
 			DefaultText: "",
@@ -25,7 +26,7 @@ var Command = &cli.Command{
 				if vmid < 100 || vmid > 999999999 {
 					return fmt.Errorf("VM vmid %vmid out of range")
 				}
-				return(nil)
+				return (nil)
 			},
 		},
 	},
@@ -37,17 +38,46 @@ func startVm(c *cli.Context) error {
 		Password: c.String("pvepassword"),
 		Realm:    c.String("pverealm"),
 	}
-	vm := proxmox.VirtualMachine{
-		VMID: proxmox.StringOrUint64(c.Uint64("vmid")),
-	}
 
 	client := proxmox.NewClient(c.String("pveurl"),
 		proxmox.WithCredentials(&credentials),
 	)
 
+	cluster, err := client.Cluster(c.Context)
+	if err != nil {
+		return err
+	}
+
+	resources, err := cluster.Resources(c.Context, "vm")
+	if err != nil {
+		return err
+	}
+
+	var vm *proxmox.VirtualMachine
+	for _, rs := range resources {
+		if rs.ID == fmt.Sprintf("%d", c.Uint64("vmid")) {
+			node, err := client.Node(c.Context, rs.Node)
+			if err != nil {
+				return err
+			}
+			vmid, err := strconv.Atoi(rs.ID)
+			if err != nil {
+				return err
+			}
+			vm, err = node.VirtualMachine(c.Context, vmid)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if vm == nil {
+		return fmt.Errorf("no vm with id found: %d", c.Uint64("vmid"))
+	}
+
 	task, err := vm.Start(context.Background())
 	if err != nil {
-		panic(err)
+		return err
 	}
 	logrus.Info(fmt.Sprintf("startvm called! (vm: %#v, task: %#v)", vm, task))
 	return nil

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -3,7 +3,6 @@ package start
 import (
 	"context"
 	"fmt"
-	"strconv"
 
 	"github.com/luthermonson/go-proxmox"
 	"github.com/sirupsen/logrus"
@@ -21,10 +20,10 @@ var Command = &cli.Command{
 			FilePath:    "",
 			Usage:       "`VMID` to start",
 			Required:    true,
-			Aliases:     []string{"c"},
+			Aliases:     []string{"v"},
 			Action: func(c *cli.Context, vmid uint64) error {
 				if vmid < 100 || vmid > 999999999 {
-					return fmt.Errorf("VM vmid %vmid out of range")
+					return fmt.Errorf("VM vmid %d out of range", vmid)
 				}
 				return (nil)
 			},
@@ -55,23 +54,19 @@ func startVm(c *cli.Context) error {
 
 	var vm *proxmox.VirtualMachine
 	for _, rs := range resources {
-		if rs.ID == fmt.Sprintf("%d", c.Uint64("vmid")) {
+		if rs.VMID == c.Uint64("vmid") {
 			node, err := client.Node(c.Context, rs.Node)
 			if err != nil {
 				return err
 			}
-			vmid, err := strconv.Atoi(rs.ID)
-			if err != nil {
-				return err
-			}
-			vm, err = node.VirtualMachine(c.Context, vmid)
+			vm, err = node.VirtualMachine(c.Context, int(rs.VMID))
 			if err != nil {
 				return err
 			}
 		}
 	}
 
-	if vm == nil {
+if vm == nil {
 		return fmt.Errorf("no vm with id found: %d", c.Uint64("vmid"))
 	}
 


### PR DESCRIPTION
no idea if this works but it does compile! should get the idea across though... you need to navigate the api a bit and make the start call to the node that has the config for the vm. this example calls cluster resources with a vm filter and loops over to finds the vm with the id passed... then it pulls the node and vm and calls the start command. 