### PR TITLE
feat(args)!: refactor args (breaking!)

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -3,7 +3,6 @@ package config
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/b-/gomox/util"
@@ -29,7 +28,8 @@ func pveVersion(c *cli.Context) error {
 			Realm:    c.String("pverealm"),
 		},
 	)
-	vmid, err := strconv.Atoi(c.Args().First())
+
+	vmid, err := util.GetVmidArg(c.Args().Slice())
 	if err != nil {
 		return err
 	}

--- a/cmd/destroy/destroy.go
+++ b/cmd/destroy/destroy.go
@@ -14,18 +14,6 @@ var Command = &cli.Command{
 	Usage:  "Delete a virtual machine",
 	Action: destroyVmCmd,
 	Flags: []cli.Flag{
-		&cli.Uint64Flag{
-			Name:     "vmid",
-			Usage:    "`VMID` to delete",
-			Required: true,
-			Aliases:  []string{"v"},
-			Action: func(c *cli.Context, vmid uint64) error {
-				if vmid < 100 || vmid > 999999999 {
-					return fmt.Errorf("VM vmid %d out of range", vmid)
-				}
-				return nil
-			},
-		},
 		&cli.BoolFlag{
 			Name:  "force",
 			Usage: "If the VM is not stopped, stop before attempting removal.",
@@ -47,7 +35,11 @@ func destroyVmCmd(c *cli.Context) error {
 			Realm:    c.String("pverealm"),
 		},
 	)
-	vmid := c.Uint64("vmid")
+
+	vmid, err := util.GetVmidArg(c.Args().Slice())
+	if err != nil {
+		return err
+	}
 
 	vm, err := util.GetVirtualMachineByVMID(c.Context, vmid, client)
 	if err != nil {

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -10,22 +10,11 @@ import (
 )
 
 var Command = &cli.Command{
-	Name:   "start",
-	Usage:  "start a virtual machine",
-	Action: startVm,
+	Name:      "start",
+	Usage:     "start a virtual machine",
+	UsageText: "gomox start <VMID>",
+	Action:    startVm,
 	Flags: []cli.Flag{
-		&cli.Uint64Flag{
-			Name:     "vmid",
-			Usage:    "`VMID` to start",
-			Required: true,
-			Aliases:  []string{"v"},
-			Action: func(c *cli.Context, vmid uint64) error {
-				if vmid < 100 || vmid > 999999999 {
-					return fmt.Errorf("VM vmid %d out of range", vmid)
-				}
-				return nil
-			},
-		},
 		&cli.BoolFlag{
 			Name:  "idempotent",
 			Usage: "Don't return error if VM is already in requested state",
@@ -47,7 +36,10 @@ func startVm(c *cli.Context) error {
 		},
 	)
 
-	vmid := c.Uint64("vmid")
+	vmid, err := util.GetVmidArg(c.Args().Slice())
+	if err != nil {
+		return err
+	}
 
 	vm, err := util.GetVirtualMachineByVMID(c.Context, vmid, client)
 	if err != nil {

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -10,22 +10,11 @@ import (
 )
 
 var Command = &cli.Command{
-	Name:   "stop",
-	Usage:  "Stop a virtual machine",
-	Action: stopVm,
+	Name:      "stop",
+	Usage:     "Stop a virtual machine",
+	UsageText: "stop <VMID>",
+	Action:    stopVm,
 	Flags: []cli.Flag{
-		&cli.Uint64Flag{
-			Name:     "vmid",
-			Usage:    "`VMID` to stop",
-			Required: true,
-			Aliases:  []string{"v"},
-			Action: func(c *cli.Context, vmid uint64) error {
-				if vmid < 100 || vmid > 999999999 {
-					return fmt.Errorf("VM vmid %d out of range", vmid)
-				}
-				return nil
-			},
-		},
 		&cli.BoolFlag{
 			Name:  "idempotent",
 			Usage: "Don't return error if VM is already in requested state",
@@ -44,7 +33,10 @@ func stopVm(c *cli.Context) error {
 			Realm:    c.String("pverealm"),
 		},
 	)
-	vmid := c.Uint64("vmid")
+	vmid, err := util.GetVmidArg(c.Args().Slice())
+	if err != nil {
+		return err
+	}
 
 	vm, err := util.GetVirtualMachineByVMID(c.Context, vmid, client)
 	if err != nil {

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -13,6 +13,7 @@ import (
 )
 
 const (
+	NoContent             = "no content" // filter this out from logs
 	DefaultTimeout        = 60 * time.Second
 	DefaultPollDuration   = time.Millisecond * 500
 	DefaultSpinnerCharSet = 9 // Classic Unix quiet |/-\|
@@ -173,7 +174,9 @@ func WaitTask(ctx context.Context, task *proxmox.Task, opts ...WaitOption) (err 
 		return err
 	}
 	taskname := taskhead[0]
-	fmt.Println(taskname)
+	if taskname != NoContent {
+		fmt.Println(taskname)
+	}
 	c := &waitConfig{
 		quiet: true, // default to quiet
 		spinnerConfig: spinnerConfig{

--- a/util/vmidarger.go
+++ b/util/vmidarger.go
@@ -1,0 +1,31 @@
+package util
+
+import (
+	"fmt"
+	"strconv"
+)
+
+const (
+	MaxVmid = 999999999
+	MinVmid = 100
+)
+
+func VmidOutOfRangeError() error {
+	return fmt.Errorf("please supply a VMID between %d and %d", MinVmid, MaxVmid)
+}
+func CheckVmidRange(vmid uint64) error {
+	if vmid < MinVmid || vmid > MaxVmid {
+		return VmidOutOfRangeError()
+	}
+	return nil
+}
+
+func GetVmidArg(args []string) (uint64, error) {
+	ivmid, err := strconv.Atoi(args[0])
+	err = CheckVmidRange(uint64(ivmid))
+	if err != nil {
+		return 0, VmidOutOfRangeError()
+	}
+	vmid := uint64(ivmid)
+	return vmid, nil
+}


### PR DESCRIPTION
Now all subcommands accept VMID as the first unnamed arg.